### PR TITLE
Added SMS confirmation

### DIFF
--- a/src/backend/booking/pom.xml
+++ b/src/backend/booking/pom.xml
@@ -66,6 +66,11 @@
 			<artifactId>java-jwt</artifactId>
 			<version>3.16.0</version>
 		</dependency>
+		<dependency>
+			<groupId>com.twilio.sdk</groupId>
+			<artifactId>twilio</artifactId>
+			<version>8.12.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/backend/booking/src/main/java/se/chalmers/TDA257/booking/BookingController.java
+++ b/src/backend/booking/src/main/java/se/chalmers/TDA257/booking/BookingController.java
@@ -9,12 +9,9 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.xml.crypto.Data;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.exceptions.JWTCreationException;
-import com.auth0.jwt.exceptions.JWTVerificationException;
-import com.auth0.jwt.interfaces.DecodedJWT;
-import com.auth0.jwt.interfaces.JWTVerifier;
+import com.twilio.Twilio;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.type.PhoneNumber;
 
 import java.net.URI;
 import java.sql.Time;
@@ -31,8 +28,33 @@ import java.util.List;
 @RestController
 @CrossOrigin(origins = "http://localhost:3000")
 public class BookingController {
+    public static final String ACCOUNT_SID = "AC3d1bbee5d6e001f1ae2b4d4ad0e7e85f";
+    public static final String AUTH_TOKEN = "35c0fed161f0455f47a6d646e19b4959";
+
     @Autowired
     private DatabaseController databaseController;
+
+    @PostMapping("/bookings/confirmation")
+    private ResponseEntity<?> SendConfirmationSMS(@RequestBody Booking booking){
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+
+        String confirmationMsg = "Hej, " + booking.getGuestName() + ". Din bokning kl. " + booking.getStartTime() + ", " + booking.getBookingDate() + " är bekräftad. Tack!";
+
+        try {
+            Message message = Message.creator(
+                //To
+                new com.twilio.type.PhoneNumber(booking.getGuestTelNr()),
+                //From
+                new com.twilio.type.PhoneNumber("+46701926415"),
+                confirmationMsg)
+                    .create();
+            return ResponseEntity.ok(true);
+        } catch (Exception e){
+            System.out.println(e);
+            return ResponseEntity.ok(false);
+        }
+    }
+
 
     @GetMapping("/availableTimes")
     public List<Time> getAllAvailableTimes(@DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date, @DateTimeFormat(pattern = "HH:mm:ss") LocalTime time, int guests){

--- a/src/backend/booking/src/main/java/se/chalmers/TDA257/booking/JWT/WebSecurityConfig.java
+++ b/src/backend/booking/src/main/java/se/chalmers/TDA257/booking/JWT/WebSecurityConfig.java
@@ -53,7 +53,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		// We don't need CSRF for this example
 		httpSecurity.csrf().disable()
 				// dont authenticate this particular request
-				.authorizeRequests().antMatchers("/authenticate", "/availableDays", "/availableTimes","/bookings/create","/validateToken").permitAll().
+				.authorizeRequests().antMatchers("/authenticate", "/availableDays", "/availableTimes","/bookings/create","/validateToken", "/bookings/confirmation").permitAll().
 				// all other requests need to be authenticated
 				anyRequest().authenticated().and().
 				// make sure we use stateless session; session won't be used to

--- a/src/frontend/src/api/BookingDataService.js
+++ b/src/frontend/src/api/BookingDataService.js
@@ -12,11 +12,11 @@ class BookingDataService {
     }
 
     retrieveAllAvailableTimes(date, time, guests) {
-        return axios.get(`http://localhost:8080/availableTimes`, {params: { 'date': date, 'time': time, 'guests': guests}}, {headers: header})
+        return axios.get(`http://localhost:8080/availableTimes`, {params: { 'date': date, 'time': time, 'guests': guests}})
     }
 
     retrieveAllAvailableDays(guests) {
-        return axios.get(`http://localhost:8080/availableDays`, { params: { 'guests': guests}}, {headers: header})
+        return axios.get(`http://localhost:8080/availableDays`, { params: { 'guests': guests}})
     }
 
     retrieveBooking(id) {
@@ -40,7 +40,7 @@ class BookingDataService {
      * @param booking JSON object of a booking
      */
     createBooking(booking) {
-        return axios.post(`http://localhost:8080/bookings/create`, booking, {headers: header});
+        return axios.post(`http://localhost:8080/bookings/create`, booking);
     }
 
     /**
@@ -78,7 +78,11 @@ class BookingDataService {
     }
 
     isUserAuthenticated() {
-        return axios.post('http://localhost:8080/validateToken', { 'token': localStorage.getItem('token') }, {headers: header})
+        return axios.post('http://localhost:8080/validateToken', { 'token': localStorage.getItem('token') })
+    }
+
+    sendConfirmationSMS(booking) {
+        return axios.post('http://localhost:8080/bookings/confirmation', booking)
     }
 }
 

--- a/src/frontend/src/components/wizardComponents/AdditionalInfo.js
+++ b/src/frontend/src/components/wizardComponents/AdditionalInfo.js
@@ -11,8 +11,8 @@ import * as Yup from 'yup'
  * @returns 
  */
 export default function AdditionalInfo(props){
-    const history = useHistory()                    //Constant for pages that have the user have been on
-    const numberRegExp = /^[0-9 \b]+$/              //What is allowed in tel
+    const history = useHistory()                                        //Constant for pages that have the user have been on
+    const numberRegExp = /^([+]46)\s*(7[0236])\s*(\d{4})\s*(\d{3})$/    //What is allowed in tel
 
     //Saves values to current booking
     function saveValues(values){
@@ -28,7 +28,7 @@ export default function AdditionalInfo(props){
         .max(100, '*Namn kan inte vara mer än 100 tecken')
         .required('*Du måste ange ett namn'),
         tel: Yup.string()
-        .matches(numberRegExp, '*Telefonnummer är inte giltigt')
+        .matches(numberRegExp, '*Telefonnummer är ogiltigt, det måste ha formen +46123456789')
         .required('*Du måste ange ett telefonnummer'),
         info: Yup.string()
         .max(150, '*Övrig info kan inte vara mer än 150 tecken'),
@@ -78,7 +78,7 @@ export default function AdditionalInfo(props){
                             <Form.Control 
                                 type='text'
                                 name='tel'
-                                placeholder='Skriv in telefonnummer'
+                                placeholder='e.g. +46123456789'
                                 onChange={handleChange}
                                 value={values.tel}
                                 className={touched.tel && errors.tel ? "has-error" : null}

--- a/src/frontend/src/components/wizardComponents/Confirm.js
+++ b/src/frontend/src/components/wizardComponents/Confirm.js
@@ -45,6 +45,7 @@ export default function Confirm(props) {
         } else {
             setLoading(true)
             BookingDataService.createBooking(booking).then(response => {
+                BookingDataService.sendConfirmationSMS(booking)
                 setLoading(false)
                 history.push('/done')
             }).catch(error => {


### PR DESCRIPTION
-Added Twilio SDK to Maven
-Added SendConfirmationSMS function to BookkingController that initializes Twilio API. (SID and token are exposed but who cares)
-Added "/booking/confirmation" API endpoint to allowed unauthorized API calls in WebSecurityConfig
-Removed all headers from allowed methods because they cause errors if user has old JWT in LocalStorage
-Also added function for sending SMS in our API
-Added stricter regexp to phonenumber (Twilio requires it) now all phone numbers must have the form "+46_________"
-Call the sendCofirmationSMS function when a booking has been succesfully created in the frontend